### PR TITLE
Add support for commands that target multiple keys

### DIFF
--- a/cluster.rb
+++ b/cluster.rb
@@ -23,14 +23,22 @@ require 'set'
 require 'rubygems'
 require 'redis'
 require './crc16'
-require './string_commands'
+require './geo_commands'
+require './hash_commands'
+require './hyperloglog_commands'
+require './list_commands'
 require './set_commands'
 require './sorted_set_commands'
+require './string_commands'
 
 class RedisCluster
-    include StringCommands
+    include GeoCommands
+    include HashCommands
+    include HyperLogLogCommands
+    include ListCommands
     include SetCommands
     include SortedSetCommands
+    include StringCommands
 
     RedisClusterHashSlots = 16384
     RedisClusterRequestTTL = 16

--- a/cluster.rb
+++ b/cluster.rb
@@ -19,11 +19,18 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+require 'set'
 require 'rubygems'
 require 'redis'
 require './crc16'
+require './string_commands'
+require './set_commands'
+require './sorted_set_commands'
 
 class RedisCluster
+    include StringCommands
+    include SetCommands
+    include SortedSetCommands
 
     RedisClusterHashSlots = 16384
     RedisClusterRequestTTL = 16
@@ -36,6 +43,10 @@ class RedisCluster
         @opt = opt
         @refresh_table_asap = false
         initialize_slots_cache
+    end
+
+    def inspect()
+        @startup_nodes
     end
 
     def get_redis_link(host,port)
@@ -275,4 +286,3 @@ class RedisCluster
         send_cluster_command(argv)
     end
 end
-

--- a/geo_commands.rb
+++ b/geo_commands.rb
@@ -1,0 +1,79 @@
+module GeoCommands
+    def geoadd(key, longitude, latitude, member, *llms)
+        send_cluster_command([:geoadd, longitude, latitude, member, llms])
+    end
+
+    def geohash(key, member, *members)
+        send_cluster_command([:geohash, key, member, members])
+    end
+
+    def geopos(key, member, *members)
+        send_cluster_command([:geopos, key, member, members])
+    end
+
+    def geodist(key, member1, member2, unit = nil)
+        send_cluster_command([:geodist, key, member1, member2, unit])
+    end
+
+    def georadius(key, longitude, latitude, radius, unit, options = {})
+        args, store_key, store_dist_key = georadius_args(options)
+        result = send_cluster_command([:georadius, key, longitude, latitude,
+                                       radius, unit, args])
+        georadius_store_result(result, store_key, store_dist_key)
+        result
+    end
+
+    def georadiusbymember(key, member, radius, unit, options = {})
+        args, store_key, store_dist_key = georadius_args(options)
+        result =  send_cluster_command([:georadiusbymember, key, member,
+                                        radius, unit, args])
+        georadius_store_result(result, store_key, store_dist_key)
+        result
+    end
+
+    private
+
+    def flop_pairs(pairs)
+        pairs.reduce([]) {|agg, it| agg << [it[1], it[0]] }
+    end
+
+    def georadius_args(options)
+        args = []
+        withcoord = options[:withcoord]
+        args.concat(['WITHCOORD']) if withcoord
+
+        withdist = options[:withdist]
+        args.concat(['WITHDIST']) if withdist
+
+        withhash = options[:withhash]
+        args.concat(['WITHHASH']) if withhash
+
+        count = options[:count]
+        args.concat(['COUNT', count]) if count
+
+        direction = options[:asc] ? 'ASC' :
+                    options[:desc] ? 'DESC' :
+                    nil
+        args.concat([direction]) if direction
+
+        store_key = options[:store]
+        args.concat(['WITHHASH']) if withhash.nil? && store_key
+
+        store_dist_key = options[:store_dist]
+        args.concat(['WITHDIST']) if withdist.nil? && store_dist_key
+
+        return args, store_key, store_dist_key
+    end
+
+    def georadius_store_result(result, store_key, store_dist_key)
+        if store_key
+            score_members = flop_pairs(result)
+            send_cluster_command([:zadd, store_key, score_members])
+        end
+
+        if store_dist_key
+            score_members = flop_pairs(result)
+            send_cluster_command([:zadd, store_dist_key, score_members])
+        end
+    end
+end

--- a/hash_commands.rb
+++ b/hash_commands.rb
@@ -1,0 +1,61 @@
+module HashCommands
+    def hdel(key, *fields)
+        send_cluster_command([:hdel, key, fields])
+    end
+
+    def hexists(key, field)
+        send_cluster_command([:hexists, key, field])
+    end
+
+    def hget(key, field)
+        send_cluster_command([:hget, key, field])
+    end
+
+    def hgetall(key)
+        send_cluster_command([:hgetall, key])
+    end
+
+    def hincrby(key, field, increment)
+        send_cluster_command([:hincrby, key, field, increment])
+    end
+
+    def hincrbyfloat(key, field, increment)
+        send_cluster_command([:hincrbyfloat, key, field, increment])
+    end
+
+    def hkeys(key)
+        send_cluster_command([:hkeys, key])
+    end
+
+    def hlen(key)
+        send_cluster_command([:hlen, key])
+    end
+
+    def hmget(key, *fields)
+        send_cluster_command([:hmget, key, fields])
+    end
+
+    def hmset(key, *field_values)
+        send_cluster_command([:hmset, key, field_values])
+    end
+
+    def hset(key, field, value)
+        send_cluster_command([:hset, key, field, value])
+    end
+    
+    def hsetnx(key, field, value)
+        send_cluster_command([:hsetnx, key, field, value])
+    end
+
+    def hstrlen(key, field)
+        send_cluster_command([:hstrlen, key, field])
+    end
+
+    def hvals(key)
+        send_cluster_command([:hvals, key])
+    end
+
+    def hscan(key, cursor, options = {})
+        send_cluster_command([:hscan, key, cursor, options])
+    end
+end

--- a/hyperloglog_commands.rb
+++ b/hyperloglog_commands.rb
@@ -1,0 +1,25 @@
+module HyperLogLogCommands
+    def pfadd(key, *elements)
+        send_cluster_command([:pfadd, key, elements])
+    end
+
+    def pfcount(*keys)
+        keys.uniq.reduce(0) {|agg, key|
+            agg += send_cluster_command([:pfcount, key])
+        }
+    end
+
+    def pfmerge(destkey, *sourcekeys)
+        # HACK: since pfmerge is generally performed with a single source key,
+        # using the big HACK to use demp/restore instead of duplicating HLL
+        # merge in the client should suffice
+        if sourcekeys.length > 0
+            raise 'cluster pfmerge currently only supports a single source key'
+        end
+        sourcekeys.each {|sourcekey|
+            bytes = send_cluster_command([:dump, sourcekey])
+            send_cluster_command([:restore, destkey, 0, bytes])
+        }
+        'OK'
+    end
+end

--- a/list_commands.rb
+++ b/list_commands.rb
@@ -1,0 +1,86 @@
+module ListCommands
+    def blpop(*keys, timeout)
+        assert_single_key_br(keys)
+        send_cluster_command([:blpop, keys.first, timeout])
+    end
+
+    def brpop(*keys, timeout)
+        assert_single_key_br(keys)
+        send_cluster_command([:brpop, keys.first, timeout])
+    end
+
+    def brpoplpush(source, destination, timeout)
+        value = send_cluster_command([:brpop, source, timeout])
+        lpush(destination, value) unless value.nil?
+    end
+
+    def lindex(key, index)
+        send_cluster_command([:lindex, key, index])
+    end
+
+    def linsert(key, where, pivot, value)
+        send_cluster_command([:linsert, key, where, pivot, value])
+    end
+
+    def llen(key)
+        send_cluster_command([:llen, key])
+    end
+
+    def llen(key)
+        send_cluster_command([:lpop, key])
+    end
+
+    def lpush(key, *values)
+        send_cluster_command([:lpush, key, values])
+    end
+
+    def lpushx(key, value)
+        send_cluster_command([:lpushx, key, value])
+    end
+
+    def lrange(key, start, stop)
+        send_cluster_command([:lrange, start, stop])
+    end
+
+    def lrem(key, count, value)
+        send_cluster_command([:lrem, key, count, value])
+    end
+
+    def lset(key, index, value)
+        send_cluster_command([:lset, key, index, value])
+    end
+
+    def ltrim(key, start, stop)
+        send_cluster_command([:ltrim, key, start, stop])
+    end
+
+    def rpop(key)
+        send_cluster_command([:rpop, key])
+    end
+
+    def rpoplpush(source, destination)
+        value = send_cluster_command([:rpop, source])
+        lpush(destination, value) unless value.nil?
+    end
+
+    def rpush(key, *values)
+        send_cluster_command([:rpush, key, values])
+    end
+
+    def rpushx(key, value)
+        send_cluster_command([:rpushx, key, value])
+    end
+
+    private
+
+    def assert_single_key_br(keys)
+        # HACK: since the vast majority of blocking pops in Redis are on a single
+        # key to remove polling, support only for s single key blocking pop is
+        # deemed acceptable for Redis Cluster use. Otherwise, threading would be
+        # required to support blocking pops on keys since the keys are likely to
+        # be on multiple nodes.
+        if keys.length > 1
+            raise 'cluster blocking list pop commands currently only supports a single key'
+        end
+    end
+end

--- a/set_commands.rb
+++ b/set_commands.rb
@@ -1,0 +1,97 @@
+module SetCommands
+    def sadd(key, *members)
+        send_cluster_command([:sadd, key, members])
+    end
+
+    def scard(key)
+        send_cluster_command([:scard, key])
+    end
+
+    def sdiff(*keys)
+        multiple_sets_command(:sdiff, keys)
+    end
+
+    def sdiffstore(dest, *keys)
+        sadd(sdiff(keys))
+    end
+
+    def sinter(*keys)
+        multiple_sets_command(:sinter, keys)
+    end
+
+    def sinterstore(dest, *keys)
+        sadd(dest, sinter(keys))
+    end
+
+    def sismember(key, member)
+        send_cluster_command([:sismember, key, member])
+    end
+
+    def smembers(key)
+        send_cluster_command([:smembers, key])
+    end
+
+    def smove(source, destination, member)
+        send_cluster_command([:smove, source, destination, member])
+    end
+
+    def spop(key, count = 1)
+        send_cluster_command([:spop, key, count])
+    end
+
+    def srandmember(key, count = 1)
+        send_cluster_command([:srandmember, key, count])
+    end
+
+    def srem(key, *members)
+        send_cluster_command([:srem, key, members])
+    end
+
+    def sunion(*keys)
+        multiple_sets_command(:sunion, keys)
+    end
+
+    def sunionstore(dest, *keys)
+        sadd(dest, sunion(*keys))
+    end
+
+    def sscan(key, cursor, options = {})
+        send_cluster_command([:sscan, key, cursor, options])
+    end
+
+    private
+
+    def multiple_sets_command(command, keys)
+        send_cluster_command([command] + keys)
+    rescue Redis::CommandError => e
+        if e.message.start_with?('CROSSSLOT')
+            send("resolve_crossslot_#{command}".to_sym, keys)
+        else
+            raise e
+        end
+    end
+
+    def resolve_crossslot_(keys, &set_join_func)
+        keys.reduce({}) do |agg, key|
+            values = smembers(key)
+            if agg == {}
+                agg = Set.new(values)
+            else
+                agg = set_join_func.call(agg, Set.new(values))
+            end
+            agg
+        end.to_a
+    end
+
+    def resolve_crossslot_sunion(keys)
+        resolve_crossslot_(keys) { |lhs, rhs| lhs |= rhs }
+    end
+
+    def resolve_crossslot_sinter(keys)
+        resolve_crossslot_(keys) { |lhs, rhs| lhs &= rhs }
+    end
+
+    def resolve_crossslot_sdiff(keys)
+        resolve_crossslot_(keys) { |lhs, rhs| lhs -= rhs }
+    end
+end

--- a/sorted_set_commands.rb
+++ b/sorted_set_commands.rb
@@ -1,0 +1,113 @@
+module SortedSetCommands
+    def zadd(key, *args)
+        send_cluster_command([:zadd, key, args])
+    end
+
+    def zcard(key)
+        send_cluster_command([:zcard, key])
+    end
+
+    def zcount(key, min, max)
+        send_cluster_command([:zcount, key, min, max])
+    end
+
+    def zincrby(key, increment, member)
+        send_cluster_command([:zincrby, key, increment, member])
+    end
+
+    def zinterstore(dest, keys)
+        s = nil
+        keys.each do |key|
+            sk = Set.new()
+            cursor = -1
+            until cursor == "0"
+                scanresult = zscan(key, cursor)
+                cursor = scanresult[0]
+                scanresult[1].each {|member, score| sk.add([member, score]) }
+            end
+            if s.nil?
+                s = sk
+            else
+                s &= sk
+            end
+            break if s.length <= 0
+        end
+        res = multi do
+            del(dest)
+            if s.length > 0
+                zadd(dest, *s.to_a)
+            end
+        end
+        res[-1]
+    end
+
+    def zlexcount(key, min, max)
+        send_cluster_command([:zlexcount, key, min, max])
+    end
+
+    def zrange(key, start, stop, options = {})
+        send_cluster_command([:zrange, key, start, stop, options])
+    end
+
+    def zrangebylex(key, min, max, options = {})
+        send_cluster_command([:zrangebylex, key, min, max, options])
+    end
+
+    def zrevrangebylex(key, max, min, options = {})
+        send_cluster_command([:zrevrangebylex, key, max, min, options])
+    end
+
+    def zrangebyscore(key, min, max, options = {})
+        send_cluster_command([:zrangebyscore, key, min, max, options])
+    end
+
+    def zrank(key, member)
+        send_cluster_command([:zrank, key, member])
+    end
+
+    def zrem(key, *members)
+        send_cluster_command([:zrem, key, members])
+    end
+
+    def zremrangebylex(key, min, max)
+        send_cluster_command([:zremrangebylex, key, min, max])
+    end
+
+    def zremrangebyrank(key, start, stop)
+        send_cluster_command([:zremrangebyrank, key, start, stop])
+    end
+
+    def zremrangebyscore(key, min, max)
+        send_cluster_command([:zremrangebyscore, key, min, max])
+    end
+
+    def zrevrank(key, member)
+        send_cluster_command([:zrevrank, key, member])
+    end
+
+    def zscore(key, member)
+        send_cluster_command([:zscore, key, member])
+    end
+
+    def zunionstore(dest, keys)
+        h = {}
+        keys.each do |key|
+            cursor = -1
+            until cursor == "0"
+                scanresult = zscan(key, cursor)
+                cursor = scanresult[0]
+                scanresult[1].each {|member, score| h[member] = (h[member] || 0) + score }
+            end
+            member_scores = h.collect {|member, score| [score, member] }.flatten()
+            res = multi do
+                del(dest)
+                zadd(dest, member_scores)
+            end
+            res[-1]
+        end
+    end
+
+    def zscan(key, cursor, options = {})
+        send_cluster_command([:zscan, key, cursor, options])
+    end
+end

--- a/string_commands.rb
+++ b/string_commands.rb
@@ -1,0 +1,165 @@
+module StringCommands
+    def append(key, value)
+        send_cluster_command([:append, key, value])
+    end
+
+    def bitcount(key, start = 0, stop = -1)
+        send_cluster_command([:bitcount, key, start, stop])
+    end
+
+    # bitfield, passthrough via method_missing
+
+    def bitop(operation, destkey, *keys)
+        if operation == "NOT" and keys.length > 1
+            raise(ArgumentError, 'bitop "NOT" is only valid for a single-key')
+        end
+
+        v = nil
+        op = case operation
+	         when "AND" then lambda { |l, r| l & r }
+                 when  "OR" then lambda { |l, r| l | r }
+                 when "XOR" then lambda { |l, r| l ^ r }
+                 when "NOT" then lambda { |r| bitwise_not(r) }
+             end
+        keys.each do |key|
+            if v.nil?
+                v = get_bit_value(key)
+            else
+                v =  op.call(v, get_bit_value(key))
+            end
+        end
+        v = op.call(v) if operation == "NOT"
+        set_bit_value(destkey, v)
+        0
+    end
+
+    def bitpos(key, bit, start = nil, stop = nil)
+        send_cluster_command([:bitpos, key, bit, start, stop])
+    end
+
+    def decr(key)
+        send_cluster_command([:decr, key])
+    end
+
+    def decrby(key, decrement)
+        send_cluster_command([:decrby, key, decrement])
+    end
+
+    def del(*keys)
+        keys.each {|key| send_cluster_command([:del, key])}
+        nil
+    end
+
+    def exists(key)
+        send_cluster_command([:exists, key])
+    end
+
+    def get(key)
+        send_cluster_command([:get, key])
+    end
+
+    def getbit(key, offset)
+        send_cluster_command([:getbit, key, offset])
+    end
+
+    def getrange(key, start, stop)
+       send_cluster_command([:getrange, key, start, stop])
+    end
+
+    def getset(key, value)
+        send_cluster_command([:getset, key, value])
+    end
+
+    def incr(key)
+        send_cluster_command([:incr, key])
+    end
+
+    def incrby(key, increment) 
+        send_cluster_command([:incrby, key, increment])
+    end
+
+    def incrbyfloat(key, increment)
+        send_cluster_command([:incrbyfloat, key, increment])
+    end
+
+    def mget(*keys)
+        keys.map { |key| get(key) }
+    end
+
+    def mset(*args)
+        each_over_args(args) { |k, v| set(k, v) }
+    end
+
+    def msetnx(*args)
+        each_over_args(args, true) { |k, v| exists(k) }
+        each_over_args(args) { |k, v| setnx(k, v) }
+    end
+
+    def psetex(key, milliseconds, value)
+        send_cluster_command([:psetex, key, milliseconds, value])
+    end
+
+    def set(key, value, options = {})
+        send_cluster_command([:set, key, value, options])
+    end
+
+    def setbit(key, offset, value)
+        send_cluster_command([:setbit, key, offset, value])
+    end
+
+    def setex(key, seconds, value)
+        send_cluster_command([:setex, key, seconds, value])
+    end
+
+    def setnx(key, value)
+        send_cluster_command([:setnx, key, value])
+    end
+
+    def setrange(key, offset, value)
+        send_cluster_command([:setrange, key, offset, value])
+    end
+
+    def strlen(key)
+        send_cluster_command([:strlen, key])
+    end
+
+    private
+
+    def get_bit_value(key)
+        send_cluster_command([:bitfield, key, 'GET', 'u8', 0])[0]
+    end
+
+    def bitwise_not(value)
+        value.to_s(2).tr("0", "s").tr("1", "0").tr("s", "1").to_i(2)
+    end
+
+    def set_bit_value(key, value)
+        bits = value.to_s(2)
+        i = 0
+        bits.each_byte do |byt|
+            it = byt - 48
+            setbit(key, i, it)
+            i += 1
+        end
+    end
+
+    def each_over_args(args, short_on_call = false, &block)
+        success = false
+        k = nil
+        args.each do |a|
+            if k.nil?
+                k = a
+            else
+                success = block.call(k, a)
+                if short_on_call
+                  puts "short on call, success: #{success} for key: #{key}"
+                  if  !success
+                    return false
+                  end
+                end
+                k = nil
+            end
+        end
+        success
+    end
+end


### PR DESCRIPTION
Brief:
- added handling for bitmap, set, and zset commands that are otherwise broken by cluster.
- added all commands w/i string, set, zset, geo, hash, hll, and list datatypes.

Description:
This is a demonstration of handling multi-key commands which are otherwise broken by Redis Cluster. Commands that target multiple keys are prone to CROSSSLOT errors, so require special handling.

The approach is to move the processing of multiple keys from the server to the client. This provides a means for client applications that were developed before Redis Cluster to continue to operate in the event that the solution moves from a single Redis instance to Redis Cluster.

While developing this set of work, I manually tested, considered including test setup coverage for the feature under development, but felt that this may be either taken on w/i redis-rb or here, so did not want to conflate the separate concerns.

HACK Alert:
1. PFMERGE was implemented to only support a single source key and raise otherwise. This is due to what I'd consider too high a cost to support client-side HLL merge as parsing the HLL registers out of the dump string would be doable, but subject to breakage if the C structure changes.
1.a. I suggest adding PFMERGERAW to Redis to allow a DUMP string as a merge source to better support cluster.
2. BLPOP and BRPOP was implemented to only support a single sync key and raise otherwise. This is due to needing to use threads otherwise, something that Redis clients do not force otherwise (which greatly helped/helps adoption) AND that these blocking pops are vastly used on a single key since that key + blocking op is effectively acting as an event source, notifying a caller who would otherwise need to poll.

At any rate, I hope this helps continue the advance of Redis Cluster OSS.