### PR TITLE
optimize populate_startup_nodes method

### DIFF
--- a/example.rb
+++ b/example.rb
@@ -2,8 +2,9 @@ require './cluster'
 
 if ARGV.length != 2
     startup_nodes = [
-        {:host => "127.0.0.1", :port => 6379},
-        {:host => "127.0.0.1", :port => 6380}
+        {:host => "127.0.0.1", :port => 7000},
+        {:host => "127.0.0.1", :port => 7001},
+        {:host => "127.0.0.1", :port => 7002}
     ]
 else
     startup_nodes = [


### PR DESCRIPTION
Hi antirez, 

   How do you do? I build the redis cluster for work recently. Then I read the source code in `redis-rb-cluster` seriously. Yeah, I am a Rubist. I find   `populate_startup_nodes` method in cluster.rb that it can be optimized. 

In `populate_startup_nodes` method,  this line 

```ruby
@nodes.each{|n| @startup_nodes << n}
```
It run 16384 times `@startup_nodes << n` , I optimize this, 

```ruby
@cluster_slots.each do |item|
            ip, port = item[2]
            name = "#{ip}:#{port}"
            node = {
                :host => ip,
                :port => port,
                :name => name
            }
            @startup_nodes << node
        end
```

`@cluster_slots` is array, and its size is  startup_nodes's size.  My `startup_nodes` is 
```ruby
startup_nodes = [
        {:host => "127.0.0.1", :port => 7000},
        {:host => "127.0.0.1", :port => 7001},
        {:host => "127.0.0.1", :port => 7002}
    ]
```
`@cluster_slots.each do |item|` just run 3 times.

And I puts the `@startup_nodes.uniq!` , the result is same as old code.

Please review my code, if you think it is good, you can merge the pull request. 

I'm happy to do this.

