### PR TITLE
fix get_key_from_command for "object" command

### DIFF
--- a/cluster.rb
+++ b/cluster.rb
@@ -130,6 +130,8 @@ class RedisCluster
         case argv[0].to_s.downcase
         when "info","multi","exec","slaveof","config","shutdown"
             return nil
+        when "object"
+            return argv[2]
         else
             # Unknown commands, and all the commands having the key
             # as first argument are handled here:


### PR DESCRIPTION
Got "Too many Cluster redirections?" forever when using redis.object('idletime', key) on cluster, 
so I fixed the key in cluster.rb according to https://redis.io/commands/object